### PR TITLE
feat: enhance users endpoint with group filtering

### DIFF
--- a/src/common/interfaces/pagination.interface.ts
+++ b/src/common/interfaces/pagination.interface.ts
@@ -2,6 +2,7 @@ export interface PaginatedResponse<T> {
   items: T[];
   meta: {
     total: number;
+    totalItems?: number;
     page: number;
     limit: number;
     totalPages: number;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -58,8 +58,9 @@ export class UsersController {
     @Query('limit') limit: number = 10,
     @Query('search') search: string = '',
     @Query('role') role?: UserRole,
+    @Query('groupId') groupId?: number,
   ) {
-    return this.usersService.findAll(page, limit, search, role);
+    return this.usersService.findAll(page, limit, search, role, groupId);
   }
 
   @HasRoles(UserRole.ADMIN)


### PR DESCRIPTION
## Summary
- include group name in user list responses
- support optional groupId filter on users endpoint
- add totalItems to pagination metadata

## Testing
- `npm run build`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a30a89cfa88324a4cdbc3f3e288183