### PR TITLE
Handle role and group when importing users via Excel

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Get,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -105,8 +106,16 @@ export class UsersController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Post('upload-excel')
   @UseInterceptors(FileInterceptor('file'))
-  async uploadExcelUsers(@UploadedFile() file: Express.Multer.File) {
-    return this.usersService.importUsersWithResponseFromExcel(file);
+  async uploadExcelUsers(
+    @UploadedFile() file: Express.Multer.File,
+    @Body('role') role: UserRole,
+    @Body('groupId', ParseIntPipe) groupId: number,
+  ) {
+    return this.usersService.importUsersWithResponseFromExcel(
+      file,
+      role,
+      groupId,
+    );
   }
 
   @HasRoles(UserRole.ADMIN)

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,11 +3,13 @@ import { JwtService } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from 'src/auth/auth.service';
 import { User } from './entities/user.entity';
+import { CourseGroup } from '../course-groups/entities/course-group.entity';
+import { Enrollment } from '../enrollment/entities/enrollment.entity';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, CourseGroup, Enrollment])],
   controllers: [UsersController],
   providers: [UsersService, AuthService, JwtService],
   exports: [UsersService],


### PR DESCRIPTION
## Summary
- allow `/users/upload-excel` to accept `role` and `groupId` form-data
- import users with supplied role and enroll them into the given group
- wire up required repositories in Users module

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: numerous eslint `@typescript-eslint` errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3145409f88324b6583e2761750387