### PR TITLE
feat: add group-aware user management

### DIFF
--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -25,12 +25,17 @@ export class GroupsController {
   }
 
   @Get()
+  async getAll(): Promise<Group[]> {
+    return this.groupsService.getAll();
+  }
+
+  @Get('paginated')
   async findAll(
     @Query('page') page: number = 1,
     @Query('limit') limit: number = 10,
     @Query('search') search?: string,
   ): Promise<PaginatedResponse<Group>> {
-    return this.groupsService.findAll(page, limit, search);
+    return this.groupsService.findAllPaginated(page, limit, search);
   }
 
   @Get(':id/assignments')

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -23,7 +23,11 @@ export class GroupsService {
     return this.groupRepository.save(group);
   }
 
-  async findAll(
+  async getAll(): Promise<Group[]> {
+    return this.groupRepository.find({ select: ['id', 'name'] });
+  }
+
+  async findAllPaginated(
     page: number = 1,
     limit: number = 10,
     search?: string,

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,12 +1,15 @@
 import {
   Column,
   Entity,
+  JoinColumn,
+  ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
   Repository,
 } from 'typeorm';
 import { Course } from '../../course/entities/course.entity';
 import { Enrollment } from '../../enrollment/entities/enrollment.entity';
+import { Group } from '../../groups/entities/group.entity';
 
 export enum UserRole {
   STUDENT = 'student',
@@ -51,6 +54,13 @@ export class User {
 
   @OneToMany(() => Course, (course) => course.professor)
   courses: Course[];
+
+  @ManyToOne(() => Group, { nullable: true })
+  @JoinColumn({ name: 'groupId' })
+  group?: Group;
+
+  @Column({ nullable: true })
+  groupId?: number;
 
   static createQueryBuilderWithInactive(repository: Repository<User>) {
     return repository.createQueryBuilder().withDeleted().where('1=1'); // This will bypass the default isActive filter

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,13 +3,12 @@ import { JwtService } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from 'src/auth/auth.service';
 import { User } from './entities/user.entity';
-import { CourseGroup } from '../course-groups/entities/course-group.entity';
-import { Enrollment } from '../enrollment/entities/enrollment.entity';
+import { Group } from '../groups/entities/group.entity';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, CourseGroup, Enrollment])],
+  imports: [TypeOrmModule.forFeature([User, Group])],
   controllers: [UsersController],
   providers: [UsersService, AuthService, JwtService],
   exports: [UsersService],


### PR DESCRIPTION
## Summary
- expose simple `/groups` endpoint for dropdowns and keep paginated variant
- allow assigning users to groups during create, update, and bulk import
- store group membership directly on users for easier filtering

## Testing
- `npm test` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa1878a5748324914af7235936a1a5