### PR TITLE
feat: add group update and excel score upload

### DIFF
--- a/src/groups/dto/update-group.dto.ts
+++ b/src/groups/dto/update-group.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateGroupDto {
+  name: string;
+}

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -5,13 +5,18 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Query,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { PaginatedResponse } from '../common/interfaces/pagination.interface';
 import { CourseAssignment } from '../course-assignments/entities/course-assignment.entity';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { SubmitGroupScoresDto } from './dto/submit-group-scores.dto';
+import { UpdateGroupDto } from './dto/update-group.dto';
 import { Group } from './entities/group.entity';
 import { GroupsService } from './groups.service';
 
@@ -52,6 +57,14 @@ export class GroupsController {
     return this.groupsService.getStudentsByGroup(id);
   }
 
+  @Patch(':id')
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateGroupDto: UpdateGroupDto,
+  ): Promise<Group> {
+    return this.groupsService.update(id, updateGroupDto);
+  }
+
   @Delete(':id')
   async remove(@Param('id') id: number): Promise<{ message: string }> {
     return this.groupsService.remove(id);
@@ -66,5 +79,14 @@ export class GroupsController {
       groupId,
       submitGroupScoresDto.scores,
     );
+  }
+
+  @Post(':id/scores/upload-excel')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadScoresFromExcel(
+    @Param('id', ParseIntPipe) groupId: number,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    return this.groupsService.uploadScoresFromExcel(groupId, file);
   }
 }


### PR DESCRIPTION
## Summary
- allow updating group name via PATCH /groups/:id
- enable uploading Excel files to submit group scores

## Testing
- `npm run lint` (fails: Unsafe member access etc)
- `npm test -- --passWithNoTests`
- `npx eslint src/groups/groups.controller.ts src/groups/groups.service.ts src/groups/dto/update-group.dto.ts`

------
https://chatgpt.com/codex/tasks/task_e_68adf8e966dc8324ab9448befd626902