### PR TITLE
Align backend course-group APIs with frontend contract

### DIFF
--- a/src/common/interfaces/pagination.interface.ts
+++ b/src/common/interfaces/pagination.interface.ts
@@ -1,10 +1,12 @@
+export interface PaginationMeta {
+  totalItems: number;
+  itemCount: number;
+  itemsPerPage: number;
+  totalPages: number;
+  currentPage: number;
+}
+
 export interface PaginatedResponse<T> {
   items: T[];
-  meta: {
-    total: number;
-    totalItems?: number;
-    page: number;
-    limit: number;
-    totalPages: number;
-  };
+  meta: PaginationMeta;
 }

--- a/src/common/utils/pagination.util.ts
+++ b/src/common/utils/pagination.util.ts
@@ -1,0 +1,23 @@
+import { PaginationMeta } from '../interfaces/pagination.interface';
+
+export function buildPaginationMeta(
+  totalItems: number,
+  currentPage: number,
+  itemsPerPage: number,
+  itemCount?: number,
+): PaginationMeta {
+  const safePage = Math.max(currentPage || 1, 1);
+  const safeLimit = Math.max(itemsPerPage || 0, 0);
+  const safeItemCount =
+    typeof itemCount === 'number' ? itemCount : Math.min(safeLimit, totalItems);
+  const totalPages = safeLimit > 0 ? Math.ceil(totalItems / safeLimit) : 1;
+
+  return {
+    totalItems,
+    itemCount: safeLimit === 0 ? totalItems : safeItemCount,
+    itemsPerPage: safeLimit,
+    totalPages,
+    currentPage:
+      totalPages === 0 ? 1 : Math.min(safePage, Math.max(totalPages, 1)),
+  };
+}

--- a/src/course-assignments/course-assignments.service.ts
+++ b/src/course-assignments/course-assignments.service.ts
@@ -4,6 +4,7 @@ import { CourseGroup } from 'src/course-groups/entities/course-group.entity';
 import { Course } from 'src/course/entities/course.entity';
 import { In, Repository } from 'typeorm';
 import { PaginatedResponse } from '../common/interfaces/pagination.interface';
+import { buildPaginationMeta } from '../common/utils/pagination.util';
 import { Enrollment } from '../enrollment/entities/enrollment.entity';
 import { User, UserRole } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
@@ -52,12 +53,7 @@ export class CourseAssignmentsService {
 
     return {
       items,
-      meta: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: buildPaginationMeta(total, page, limit, items.length),
     };
   }
 

--- a/src/course-groups/course-groups.module.ts
+++ b/src/course-groups/course-groups.module.ts
@@ -1,14 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { CourseGroupsService } from './course-groups.service';
+import { Course } from '../course/entities/course.entity';
+import { Enrollment } from '../enrollment/entities/enrollment.entity';
+import { User } from '../users/entities/user.entity';
 import { CourseGroupsController } from './course-groups.controller';
+import { CourseGroupsService } from './course-groups.service';
 import { CourseGroup } from './entities/course-group.entity';
-import { User } from 'src/users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CourseGroup,User])],
+  imports: [TypeOrmModule.forFeature([CourseGroup, User, Enrollment, Course])],
   controllers: [CourseGroupsController],
   providers: [CourseGroupsService],
-  exports: [CourseGroupsService]
+  exports: [CourseGroupsService],
 })
 export class CourseGroupsModule {}

--- a/src/course-groups/dto/create-course-group.dto.ts
+++ b/src/course-groups/dto/create-course-group.dto.ts
@@ -1,4 +1,16 @@
+import { IsInt, IsOptional, IsPositive } from 'class-validator';
+
 export class CreateCourseGroupDto {
+  @IsInt()
+  @IsPositive()
   courseId: number;
+
+  @IsInt()
+  @IsPositive()
   professorId: number;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  capacity?: number;
 }

--- a/src/course-groups/dto/manage-students.dto.ts
+++ b/src/course-groups/dto/manage-students.dto.ts
@@ -1,0 +1,8 @@
+import { ArrayNotEmpty, IsArray, IsInt } from 'class-validator';
+
+export class ManageStudentsDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  studentIds: number[];
+}

--- a/src/course-groups/dto/update-course-group.dto.ts
+++ b/src/course-groups/dto/update-course-group.dto.ts
@@ -1,4 +1,18 @@
+import { IsInt, IsOptional, IsPositive } from 'class-validator';
+
 export class UpdateCourseGroupDto {
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
   courseId?: number;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
   professorId?: number;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  capacity?: number;
 }

--- a/src/course-groups/dto/usernames.dto.ts
+++ b/src/course-groups/dto/usernames.dto.ts
@@ -1,0 +1,8 @@
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
+
+export class UsernamesDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  usernames: string[];
+}

--- a/src/course-groups/entities/course-group.entity.ts
+++ b/src/course-groups/entities/course-group.entity.ts
@@ -23,6 +23,9 @@ export class CourseGroup {
   @Column({ default: 0 })
   currentEnrollment: number;
 
+  @Column({ type: 'int', nullable: true })
+  capacity: number | null;
+
   @ManyToOne(() => Course)
   @JoinColumn({ name: 'courseId' })
   course: Course;
@@ -31,10 +34,11 @@ export class CourseGroup {
   courseId: number;
 
   @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'professorId' })
   professor: User | null;
 
-  @Column()
-  professorId: number;
+  @Column({ nullable: true })
+  professorId: number | null;
 
   @OneToMany(() => Enrollment, (enrollment) => enrollment.group, {
     cascade: true,

--- a/src/course-groups/interfaces/enrollment-result.interface.ts
+++ b/src/course-groups/interfaces/enrollment-result.interface.ts
@@ -1,8 +1,0 @@
-export interface EnrollmentResult {
-  message: string;
-  groupId: number;
-  enrollmentResults: {
-    successful: number[];
-    failed: Array<{ studentId: number; reason: string }>;
-  };
-}

--- a/src/course-groups/interfaces/group-response.interface.ts
+++ b/src/course-groups/interfaces/group-response.interface.ts
@@ -1,0 +1,45 @@
+import { UserRole } from '../../users/entities/user.entity';
+
+export interface GroupCourseInfo {
+  id: number;
+  name: string;
+}
+
+export interface GroupProfessorInfo {
+  id: number;
+  username: string;
+  firstName?: string;
+  lastName?: string;
+  role: UserRole;
+}
+
+export interface GroupResponse {
+  id: number;
+  groupNumber: number;
+  currentEnrollment: number;
+  capacity: number | null;
+  course: GroupCourseInfo | null;
+  professor: GroupProfessorInfo | null;
+}
+
+export interface GroupInfoSummary {
+  id: number;
+  groupNumber: number;
+  courseName: string | null;
+  capacity: number | null;
+  currentEnrollment: number;
+}
+
+export interface GroupStudentSummary {
+  id: number;
+  username: string;
+  firstName?: string;
+  lastName?: string;
+  isEnrolled: boolean;
+  canEnroll: boolean;
+}
+
+export interface GroupStudentsResponse {
+  students: GroupStudentSummary[];
+  groupInfo: GroupInfoSummary;
+}

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -6,6 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PaginatedResponse } from '../common/interfaces/pagination.interface';
+import { buildPaginationMeta } from '../common/utils/pagination.util';
 import { CourseGroup } from '../course-groups/entities/course-group.entity';
 import { CreateCourseDto } from './dto/create-grade.dto';
 import { Course } from './entities/course.entity';
@@ -47,12 +48,7 @@ export class CourseService {
 
     return {
       items,
-      meta: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: buildPaginationMeta(total, page, limit, items.length),
     };
   }
 

--- a/src/enrollment/enrollment.controller.ts
+++ b/src/enrollment/enrollment.controller.ts
@@ -17,6 +17,7 @@ import {
 } from '@nestjs/common';
 import { Request } from 'express';
 import { PaginatedResponse } from 'src/common/interfaces/pagination.interface';
+import { buildPaginationMeta } from 'src/common/utils/pagination.util';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { EnrollmentService } from './enrollment.service';
 import { EnrollmentResponse } from './interfaces/enrollment-response.interface';
@@ -131,12 +132,7 @@ export class EnrollmentController {
       if (error instanceof NotFoundException) {
         return {
           items: [],
-          meta: {
-            total: 0,
-            page,
-            limit,
-            totalPages: 0,
-          },
+          meta: buildPaginationMeta(0, page, limit, 0),
         };
       }
       throw error;

--- a/src/enrollment/enrollment.service.ts
+++ b/src/enrollment/enrollment.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PaginatedResponse } from 'src/common/interfaces/pagination.interface';
+import { buildPaginationMeta } from 'src/common/utils/pagination.util';
 import { Repository } from 'typeorm';
 import { CourseAssignment } from 'src/course-assignments/entities/course-assignment.entity';
 import { Course } from '../course/entities/course.entity';
@@ -267,12 +268,7 @@ export class EnrollmentService {
 
     return {
       items,
-      meta: {
-        total,
-        page,
-        limit,
-        totalPages,
-      },
+      meta: buildPaginationMeta(total, page, limit, items.length),
     };
   }
 

--- a/src/groups/entities/group.entity.ts
+++ b/src/groups/entities/group.entity.ts
@@ -1,4 +1,9 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 @Entity('groups')
 export class Group {
@@ -7,4 +12,7 @@ export class Group {
 
   @Column()
   name: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
 }

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  DefaultValuePipe,
   Delete,
   Get,
   Param,
@@ -30,14 +31,9 @@ export class GroupsController {
   }
 
   @Get()
-  async getAll(): Promise<Group[]> {
-    return this.groupsService.getAll();
-  }
-
-  @Get('paginated')
   async findAll(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
     @Query('search') search?: string,
   ): Promise<PaginatedResponse<Group>> {
     return this.groupsService.findAllPaginated(page, limit, search);

--- a/src/migrations/AddCreatedAtToGroups.ts
+++ b/src/migrations/AddCreatedAtToGroups.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddCreatedAtToGroups implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const hasColumn = await queryRunner.hasColumn('groups', 'createdAt');
+
+    if (!hasColumn) {
+      await queryRunner.addColumn(
+        'groups',
+        new TableColumn({
+          name: 'createdAt',
+          type: 'timestamp',
+          default: 'CURRENT_TIMESTAMP',
+        }),
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const hasColumn = await queryRunner.hasColumn('groups', 'createdAt');
+
+    if (hasColumn) {
+      await queryRunner.dropColumn('groups', 'createdAt');
+    }
+  }
+}

--- a/src/migrations/ReintroduceCapacityAndNullableProfessor.ts
+++ b/src/migrations/ReintroduceCapacityAndNullableProfessor.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class ReintroduceCapacityAndNullableProfessor
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const hasCapacity = await queryRunner.hasColumn(
+      'course_groups',
+      'capacity',
+    );
+
+    if (!hasCapacity) {
+      await queryRunner.addColumn(
+        'course_groups',
+        new TableColumn({
+          name: 'capacity',
+          type: 'int',
+          isNullable: true,
+        }),
+      );
+    } else {
+      await queryRunner.changeColumn(
+        'course_groups',
+        'capacity',
+        new TableColumn({
+          name: 'capacity',
+          type: 'int',
+          isNullable: true,
+        }),
+      );
+    }
+
+    await queryRunner.changeColumn(
+      'course_groups',
+      'professorId',
+      new TableColumn({
+        name: 'professorId',
+        type: 'int',
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const hasCapacity = await queryRunner.hasColumn(
+      'course_groups',
+      'capacity',
+    );
+
+    if (hasCapacity) {
+      await queryRunner.dropColumn('course_groups', 'capacity');
+    }
+
+    await queryRunner.changeColumn(
+      'course_groups',
+      'professorId',
+      new TableColumn({
+        name: 'professorId',
+        type: 'int',
+        isNullable: false,
+      }),
+    );
+  }
+}

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -7,6 +7,7 @@ import { CreateTicketDto } from './dto/create-ticket.dto';
 import { UpdateTicketDto } from './dto/update-ticket.dto';
 import { Comment } from './entities/comment.entity';
 import { Ticket } from './entities/ticket.entity';
+import { buildPaginationMeta } from '../common/utils/pagination.util';
 
 @Injectable()
 export class TicketsService {
@@ -51,12 +52,7 @@ export class TicketsService {
 
     return {
       items,
-      meta: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: buildPaginationMeta(total, page, limit, items.length),
     };
   }
 
@@ -180,12 +176,7 @@ export class TicketsService {
 
     return {
       items,
-      meta: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: buildPaginationMeta(total, page, limit, items.length),
     };
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -9,6 +9,7 @@ import { Enrollment } from 'src/enrollment/entities/enrollment.entity';
 import { Group } from 'src/groups/entities/group.entity';
 import { Brackets, Repository } from 'typeorm';
 import { PaginatedResponse } from '../common/interfaces/pagination.interface';
+import { buildPaginationMeta } from '../common/utils/pagination.util';
 import { User, UserRole } from './entities/user.entity';
 
 @Injectable()
@@ -63,13 +64,7 @@ export class UsersService {
 
     return {
       items: users,
-      meta: {
-        total,
-        totalItems: total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: buildPaginationMeta(total, page, limit, users.length),
     };
   }
 
@@ -98,7 +93,9 @@ export class UsersService {
     });
 
     if (groupId) {
-      const group = await this.groupRepository.findOne({ where: { id: groupId } });
+      const group = await this.groupRepository.findOne({
+        where: { id: groupId },
+      });
       if (!group) {
         throw new BadRequestException('گروه یافت نشد');
       }


### PR DESCRIPTION
## Summary
- add a shared pagination meta builder and update paginated services to emit `{ items, meta }`
- rewrite course-group service/controller contracts to handle capacity, student management, and available-student lookups expected by the frontend
- expose migrations to restore course group capacity/null professor and add creation timestamps to groups

## Testing
- npm run build
- npm run lint *(fails: legacy eslint violations in auth, assignments, enrollment, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68cc55a0e7e88324b7d6c29b85d52e40