### PR TITLE
Fix manage students API for course groups

### DIFF
--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -1,13 +1,21 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CourseAssignment } from '../course-assignments/entities/course-assignment.entity';
+import { CourseGroup } from '../course-groups/entities/course-group.entity';
 import { Enrollment } from '../enrollment/entities/enrollment.entity';
 import { Group } from './entities/group.entity';
 import { GroupsController } from './groups.controller';
 import { GroupsService } from './groups.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Group, Enrollment, CourseAssignment])],
+  imports: [
+    TypeOrmModule.forFeature([
+      Group,
+      Enrollment,
+      CourseAssignment,
+      CourseGroup,
+    ]),
+  ],
   controllers: [GroupsController],
   providers: [GroupsService],
   exports: [GroupsService],


### PR DESCRIPTION
## Summary
- allow the groups module to load course group entities when retrieving students
- return enriched enrollment details when a course group is found and keep a legacy fallback for classic groups

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm test *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8833d9988324b304bbdfe06bcacb