### PR TITLE
Ensure group enrollments are returned for course groups

### DIFF
--- a/src/enrollment/enrollment.module.ts
+++ b/src/enrollment/enrollment.module.ts
@@ -6,10 +6,17 @@ import { EnrollmentController } from './enrollment.controller';
 import { EnrollmentService } from './enrollment.service';
 import { Enrollment } from './entities/enrollment.entity';
 import { CourseAssignment } from '../course-assignments/entities/course-assignment.entity';
+import { CourseGroup } from '../course-groups/entities/course-group.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Enrollment, Course, User, CourseAssignment]),
+    TypeOrmModule.forFeature([
+      Enrollment,
+      Course,
+      User,
+      CourseAssignment,
+      CourseGroup,
+    ]),
   ],
   controllers: [EnrollmentController],
   providers: [EnrollmentService],

--- a/src/enrollment/entities/enrollment.entity.ts
+++ b/src/enrollment/entities/enrollment.entity.ts
@@ -32,8 +32,14 @@ export class Enrollment {
   @JoinColumn({ name: 'courseId' })
   course: Course;
 
-  @ManyToOne(() => CourseGroup, (courseGroup) => courseGroup.enrollments)
-  group: CourseGroup;
+  @ManyToOne(() => CourseGroup, (courseGroup) => courseGroup.enrollments, {
+    nullable: true,
+  })
+  @JoinColumn({ name: 'groupId' })
+  group: CourseGroup | null;
+
+  @Column({ nullable: true })
+  groupId: number | null;
 
   @Column({ nullable: true, type: 'float' })
   score: number;


### PR DESCRIPTION
## Summary
- persist course group identifiers on enrollment records and expose the column in the entity
- update course assignment enrollment flows to require a course group, migrate legacy enrollments, and scope queries to the correct group
- adjust course and legacy group student lookups to query active enrollments (with a fallback for historical data) and refresh counts

## Testing
- npm run lint *(fails: numerous pre-existing lint errors in unrelated auth, ticket, and user modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0983101483249fdcaefbc95eb768