### PR TITLE
Add user-based fallback students for group listings

### DIFF
--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CourseAssignment } from '../course-assignments/entities/course-assignment.entity';
 import { CourseGroup } from '../course-groups/entities/course-group.entity';
 import { Enrollment } from '../enrollment/entities/enrollment.entity';
+import { User } from '../users/entities/user.entity';
 import { Group } from './entities/group.entity';
 import { GroupsController } from './groups.controller';
 import { GroupsService } from './groups.service';
@@ -14,6 +15,7 @@ import { GroupsService } from './groups.service';
       Enrollment,
       CourseAssignment,
       CourseGroup,
+      User,
     ]),
   ],
   controllers: [GroupsController],


### PR DESCRIPTION
## Summary
- include the User repository in the groups module and service to load active students when enrollments are empty
- reuse the user list as a fallback for both legacy groups and course-groups while keeping the stored enrollment counts unchanged
- return fallback students as enrollable candidates so empty responses are replaced by actual user data

## Testing
- npm run lint *(fails: existing lint violations in unrelated auth, enrollment, course, users, and ticket files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd15cd01e08324a4159af2a83ba833